### PR TITLE
Fixes for sub routing

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -4,11 +4,11 @@
     <meta name="viewport" content="width=device-width, maximum-scale=1.0, minimum-scale=1.0, initial-scale=1.0" />
     <meta charset="utf-8">
     <title>React Router + Webpack 2 + Dynamic Chunk Navigation</title>
-    <link href="./style.css" media="all" rel="stylesheet" />
+    <link href="/style.css" media="all" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>
-    <script src="./vendor.bundle.js"></script>
-    <script src="./bundle.js"></script>
+    <script src="/vendor.bundle.js"></script>
+    <script src="/bundle.js"></script>
   </body>
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,15 +10,18 @@ module.exports = {
   context: path.join(__dirname, './client'),
   entry: {
     js: [
-      'index', 'pages/Home'
+      'index',
+      'pages/Home'
     ],
     vendor: [
-      'react', 'react-dom'
+      'react',
+      'react-dom'
     ]
   },
   output: {
     path: path.join(__dirname, './static'),
-    filename: 'bundle.js'
+    filename: 'bundle.js',
+    publicPath: '/'
   },
   module: {
     loaders: [


### PR DESCRIPTION
In order for sub-routing to work you need to use absolute paths and specify the `publicPath` property in the output config
