### PR TITLE
Fixes issue #3

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "babel-preset-es2015-native-modules": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "css-loader": "^0.23.1",
-    "extract-text-webpack-plugin": "^1.0.1",
+    "extract-text-webpack-plugin": "^2.0.0-beta.3",
     "file-loader": "^0.8.5",
     "node-sass": "^3.5.0-beta.1",
     "sass-loader": "^3.1.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,7 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');
 
 const nodeEnv = process.env.NODE_ENV || 'development';
 const isProd = nodeEnv === 'production';
+let extractCSS = new ExtractTextPlugin('style.css');
 
 module.exports = {
   devtool: isProd ? 'hidden-source-map' : 'cheap-eval-source-map',
@@ -18,7 +19,8 @@ module.exports = {
   },
   output: {
     path: path.join(__dirname, './static'),
-    filename: 'bundle.js'
+    filename: 'bundle.js',
+    publicPath: '/',
   },
   module: {
     loaders: [
@@ -31,7 +33,7 @@ module.exports = {
       },
       {
         test: /\.scss$/,
-        loaders: ExtractTextPlugin.extract('style-loader', 'css-loader!sass-loader')
+        loaders: extractCSS.extract(['css','sass'])
       },
       {
         test: /\.(js|jsx)$/,
@@ -80,9 +82,7 @@ module.exports = {
     new webpack.DefinePlugin({
       'process.env': { NODE_ENV: JSON.stringify(nodeEnv) }
     }),
-    new ExtractTextPlugin('style.css', {
-      allChunks: true
-    })
+    extractCSS,
   ],
   devServer: {
     contentBase: './client',


### PR DESCRIPTION
If you try to run project currently, it doesn't compile on `npm start` it throws errors as `extract-text-webpack-plugin` has changed API in order to work with webpack2.

It will fix #3 
