### PR TITLE
fix(config): remove inject option

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -113,7 +113,6 @@ module.exports = {
   devServer: {
     contentBase: './client',
     historyApiFallback: true,
-    inject: true,
     port: 3000,
     compress: isProd,
     stats: { colors: true },


### PR DESCRIPTION
Im honestly not sure exactly what the `inject` option does for webpack dev server (pretty sure its deprecated in the latest version of webpack dev server) as I could not find any info on it but: A: removing it gets rid of this error `Invalid configuration object. webpack-dev-server has been initialised using a configuration object that does not match the API schema.` when trying to build the app, B: it does not seem to break anything with the build when removing it. If i'm being ignorant and this does actually break something, feel free to close this PR (: