### PR TITLE
PRPL: Add Service Worker caching support

### DIFF
--- a/client/index.ejs
+++ b/client/index.ejs
@@ -8,5 +8,10 @@
   <body>
     <div id="root"></div>
     <script>window.__CHUNKS=[];</script>
+    <script>
+        if ('serviceWorker' in navigator) {
+          navigator.serviceWorker.register('/my-service-worker.js');
+        }
+    </script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "node-sass": "^3.13.0",
     "sass-loader": "^3.2.3",
     "style-loader": "^0.13.1",
+    "sw-precache-webpack-plugin": "^0.7.2",
     "webpack": "^2.1.0-beta.27",
     "webpack-dev-server": "^2.1.0-beta.10"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 const webpack = require('webpack');
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const SWPrecacheWebpackPlugin = require('sw-precache-webpack-plugin');
 
 const nodeEnv = process.env.NODE_ENV || 'development';
 const isProd = nodeEnv === 'production';
@@ -38,6 +39,18 @@ const plugins = [
   }),
 
   /**
+   * Precache resources using Service Workers
+   */
+  new SWPrecacheWebpackPlugin({
+      cacheId: 'react-dynamic-route-loading-es6',
+      filename: 'my-service-worker.js',
+      runtimeCaching: [{
+        handler: 'cacheFirst',
+        urlPattern: /(.*?)/
+      }],
+    }),
+
+  /**
    * Create a JSON file that contains file names of all chunks
    */
   function() {
@@ -59,7 +72,7 @@ const plugins = [
         cb(null, htmlPluginData);
       });
     });
-  },
+  }
 ];
 
 
@@ -122,7 +135,7 @@ module.exports = {
     rules: [
       {
         test: /\.html$/,
-        use: 'file-loader',
+        loader: 'file-loader',
         query: {
           name: '[name].[ext]'
         }


### PR DESCRIPTION
This PR adds support for SW caching as we discussed in #12. Didn't take too long to add :)

Confirmed as working from local tests + checking the cache in DevTools > Application panel.

![screen shot 2017-01-21 at 2 40 29 pm](https://cloud.githubusercontent.com/assets/110953/22178342/6d1a901e-dfe8-11e6-8ced-e78e5078ccb9.jpg)

In my fork I've created a steps/7-service-worker branch. If you'd like to create a similar branch on your end I can PR to that but for now PRing against your steps/6 branch. Edits enabled for maintainers in case there are changes you would like to make.