### PR TITLE
Fix cmd command for Windows

### DIFF
--- a/build.js
+++ b/build.js
@@ -2,12 +2,12 @@
 var exec = require('child_process').exec;
 
 var executable = (!process.argv[3].indexOf('server')) ? 'webpack-dev-server' : 'webpack';
-var cmdLine = './node_modules/.bin/' + executable;
+var cmdLine = '"./node_modules/.bin/' + executable + '"';
 var environ = (!process.argv[2].indexOf('development')) ? 'development' : 'production';
 var command;
 
 if (process.platform === 'win32') {
-  cmdLine = 'set NODE_ENV=' + environ + '&& ' + cmdLine;
+  cmdLine = 'set NODE_ENV=' + environ + ' && ' + cmdLine;
 } else {
   cmdLine = 'NODE_ENV=' + environ + ' ' + cmdLine;
 }


### PR DESCRIPTION
In Windows string `'./node_modules/.bin/'` must be enclosed in double quotes, as it contains character `'.'` (dot). Otherwise, you will get the error: `'.'` is not recognized as an internal or external command, operable program or batch file.